### PR TITLE
add replicate index for bam file path

### DIFF
--- a/atac.bds
+++ b/atac.bds
@@ -12,7 +12,7 @@ preseq 		:= false 	help Do preseq analysis.
 subsample 	:= false 	help Subsample replicates. Use '-nreads [NO_READS]' (default: 15000000) to specify # reads to subsample.
 true_rep 	:= false 	help No pseudo-replicates.
 idr 		:= false 	help Perform IDR analysis on called peaks. This will change p-value threshold (0.01->0.1) in MACS2 peak calling.
-no_ataqc 	:= false 	help No ATAQC 
+no_ataqc 	:= false 	help No ATAQC
 csem	 	:= false	help Use CSEM for alignment.
 //ataqc(parameters to be defined: species, blacklist, dnase, tss, prom, enh, reg2map and roadmap_meta).
 mem_ataqc 	:= "8G"		help Max. memory for ATAQC (default: 8G).
@@ -61,7 +61,7 @@ report()
 
 
 void init_atac() {
-	
+
 	if ( is_input_legacy() ) { // legacy input method taking first 8 parameters from cmd. line
 
 		bwt2_idx 	= args[0].trim()
@@ -86,7 +86,7 @@ void init_atac() {
 		csem 		= false
 
 		input 		= "fastq"
-	
+
 		print("\n\nLegacy input method found (8 parameters)\n")
 		print("========================================\n")
 		print( "Bowtie2 index\t\t: $bwt2_idx\n" )
@@ -121,7 +121,7 @@ void init_atac() {
 	}
 
 	if ( input == "" ) { // determine input type
-		
+
 		if ( get_filt_bam(0,1) != "" ) 	input = "filt_bam"
 		if ( get_bam(0,1) != "" ) 	input = "bam"
 		if ( get_fastq(0,1,1) != "" ) 	input = "fastq"
@@ -138,7 +138,7 @@ void print_atac() {
 
 	print( "\n\n== atac pipeline settings\n")
 	print( "Single ended data set?\t: $se\n")
-	print( "Input data type\t\t: $input\n")		
+	print( "Input data type\t\t: $input\n")
 	print( "Fastqs are trimmed?\t: $trimmed_fastq\n")
 	print( "# Replicates\t\t: "+ get_num_rep() + "\n")
 	print( "MACS2 peak calling\t: " + !mapping + "\n")
@@ -186,7 +186,7 @@ void chk_input_data() {
 			print("\nDefault IDR threshold is found ($idr_thresh). Set it to 0.1 .\n")
 			idr_thresh = 0.1
 		}
-	
+
 		print("\nSet p-value threshold in MACS2 peak calling to 0.1 .\n")
 
 		pval_thresh_macs2 = 0.1
@@ -272,7 +272,7 @@ void chk_ataqc() {
 void atac() {
 
 	for (int rep=1; rep<=get_num_rep(); rep++) {
-		
+
 		par _atac( rep )
 	}
 
@@ -300,7 +300,7 @@ void _atac_SE( int rep ) {
 		fastq{rep} = fastqs[0]
 
 		string p1, label_fastq
-		
+
 		if ( trimmed_fastq ) {
 			p1 = fastq{rep}
 		}
@@ -314,7 +314,7 @@ void _atac_SE( int rep ) {
 		if ( csem ) {
 			( bam{rep}, align_log{rep} ) = _bowtie2_csem( p1, atac_out_dir, info, fastq_graph_id, "bam\\n($info)" )
 		}
-		else {		
+		else {
 			( bam{rep}, align_log{rep} ) = _bowtie2( p1, atac_out_dir, info, fastq_graph_id, "bam\\n($info)" )
 		}
 		wait
@@ -322,7 +322,7 @@ void _atac_SE( int rep ) {
 
 	if ( is_input_fastq() || is_input_bam() ) {
 
-		if ( is_input_bam() ) bam{rep} = get_bam( 0, rep )			
+		if ( is_input_bam() ) bam{rep} = get_bam( 0, rep )
 
 		( filt_bam{rep}, dup_qc{rep}, flagstat_nodup_qc{rep}, pbc_qc{rep} ) = _dedup_bam( bam{rep}, atac_out_dir, info )
 		wait
@@ -393,7 +393,7 @@ void _atac_SE( int rep ) {
 			//wait
 
 			//_report_atac( atac_out_dir, info )
-		}		
+		}
 	}
 
 	if ( !mapping && subsampled_tag != "" ) { // cross correlation analysis
@@ -418,7 +418,7 @@ void _atac_PE( int rep ) {
 
 		// correct if user skipped replicate id like (-fastq[PAIR]) instead of (-fastq[REP]_[PAIR])
 		if ( (get_num_rep()==1) && (fastqs.size()<2) && (get_fastq( 0, 2, 1 )!="") ) fastqs.add( get_fastq( 0, 2, 1 ) )
- 
+
 		fastq1 := fastqs[0]
 		fastq2 := fastqs[1]
 
@@ -445,7 +445,7 @@ void _atac_PE( int rep ) {
 
 	if ( is_input_fastq() || is_input_bam() ) {
 
-		if ( is_input_bam() ) bam{rep} = get_bam( 0, rep )			
+		if ( is_input_bam() ) bam{rep} = get_bam( 0, rep )
 
 		(filt_bam{rep}, dup_qc{rep}, flagstat_nodup_qc{rep}, pbc_qc{rep} ) = _dedup_bam_PE( bam{rep}, atac_out_dir, info )
 		wait
@@ -463,7 +463,7 @@ void _atac_PE( int rep ) {
 		if ( subsample || !true_rep ) {
 
 			bedpe := _bam_to_bedpe( filt_bam{rep}, atac_out_dir, info, "filt_bam\\n($info)", "bedpe\\n($info)" )
-			wait 
+			wait
 
 			string subsampled_bedpe
 
@@ -497,10 +497,10 @@ void _atac_PE( int rep ) {
 
 			if ( !subsample ) {
 
-				shifted_tags{rep} = _bam_to_bed_atac( filt_bam, atac_out_dir, info )
+				shifted_tags{rep} = _bam_to_bed_atac( filt_bam{rep}, atac_out_dir, info )
 				wait
 			}
-			
+
 			if ( !true_rep ) {
 
 				( peaks_pr1{rep}, fc_bigwig{rep+"_pr1"}, pval_bigwig{rep+"_pr1"} ) \
@@ -601,7 +601,7 @@ void post_atac() {
 }
 
 void do_idr() {
-	
+
 	if ( mapping ) return
 
 	if ( !idr || get_num_rep() != 2 ) return
@@ -620,7 +620,7 @@ void do_idr() {
 	filt_peaks{1} 	= _filt_out_bad_npeaks( peaks{1}, rep1_dir, "rep1" )
 	filt_peaks{2} 	= _filt_out_bad_npeaks( peaks{2}, rep2_dir, "rep2"  )
 	filt_peak_pooled= _filt_out_bad_npeaks( peak_pooled, pooled_dir, "pooled" )
-	
+
 	if ( !true_rep ) {
 
 		filt_peaks_pr1{1} = _filt_out_bad_npeaks( peaks_pr1{1}, rep1_dir, "rep1_pr1" )
@@ -663,7 +663,7 @@ void do_idr() {
 string[] _ataqc( string fastq1, string fastq2, string bam, string align_log, string srt_bam, \
 		 string dup_log, string filt_bam, string bed, string bigwig, string peak, \
 		 string o_dir, string info ) {
-	
+
 	prefix 		:= replace_dir( rm_ext( fastq1, ["fastq","fq"] ), o_dir ) + ( (fastq2!="") ? ".PE2SE" : "" )
 	html 		:= "$prefix"+"_qc.html"
 	txt 		:= "$prefix"+"_qc.txt"
@@ -724,10 +724,10 @@ string[] _ataqc( string fastq1, string fastq2, string bam, string align_log, str
 void report() { // HTML atac report
 
 	wait
-	
+
 	html := report_header.read()
 
-	html += _html_atac_files() 	// treeview for directory and file structure 
+	html += _html_atac_files() 	// treeview for directory and file structure
 	html += _html_atac_tracks() 	// epigenome browser tracks
 	html += _html_atac_graphviz() 	// graphviz workflow diagram
 	html += _html_atac_QC()	 	// show QC tables and images
@@ -760,9 +760,9 @@ string _html_atac_files() {
 
 		info 	:= get_num_rep()==1 ? "." : "rep$rep"
 		key 	:= "$rep"
-		
+
 		align_out_dir 	:= "$out_dir/$info"
-		
+
 		html += "<tr data-tt-id='$key'><td>" + "Replicate $rep ($info)"+ "</td><td>"+ _html_link_url( align_out_dir ) +"</td></tr>"
 
 		// replicates and controls
@@ -864,11 +864,11 @@ string _html_atac_files() {
 		html += "<tr data-tt-id='idr'><td>" + "IDR peaks"+ "</td><td>"+ _html_link_url( idr_out_dir ) +"</td></tr>"
 
  		if ( idr_tr!="" ) html += "<tr data-tt-id='idr_tr' data-tt-parent-id='idr'><td>" + "True replicates"+ "</td><td>"+ _html_link_url( idr_tr ) +"</td></tr>"
-		if ( idr_pr_rep1!="" ) html += "<tr data-tt-id='idr_pr_rep1' data-tt-parent-id='idr'><td>" + "Pseudo-replicates (rep1)"+ "</td><td>"+ _html_link_url( idr_pr_rep1 ) +"</td></tr>"		
-		if ( idr_pr_rep2!="" ) html += "<tr data-tt-id='idr_pr_rep2' data-tt-parent-id='idr'><td>" + "Pseudo-replicates (rep2)"+ "</td><td>"+ _html_link_url( idr_pr_rep2 ) +"</td></tr>"		
-		if ( idr_ppr!="" ) html += "<tr data-tt-id='idr_ppr' data-tt-parent-id='idr'><td>" + "Pooled pseudo-replicates"+ "</td><td>"+ _html_link_url( idr_ppr ) +"</td></tr>"		
-		if ( idr_opt!="" ) html += "<tr data-tt-id='idr_opt' data-tt-parent-id='idr'><td>" + "Optimal set"+ "</td><td>"+ _html_link_url( idr_opt ) +"</td></tr>"		
-		if ( idr_consv!="" ) html += "<tr data-tt-id='idr_consv' data-tt-parent-id='idr'><td>" + "Conservative set"+ "</td><td>"+ _html_link_url( idr_consv ) +"</td></tr>"		
+		if ( idr_pr_rep1!="" ) html += "<tr data-tt-id='idr_pr_rep1' data-tt-parent-id='idr'><td>" + "Pseudo-replicates (rep1)"+ "</td><td>"+ _html_link_url( idr_pr_rep1 ) +"</td></tr>"
+		if ( idr_pr_rep2!="" ) html += "<tr data-tt-id='idr_pr_rep2' data-tt-parent-id='idr'><td>" + "Pseudo-replicates (rep2)"+ "</td><td>"+ _html_link_url( idr_pr_rep2 ) +"</td></tr>"
+		if ( idr_ppr!="" ) html += "<tr data-tt-id='idr_ppr' data-tt-parent-id='idr'><td>" + "Pooled pseudo-replicates"+ "</td><td>"+ _html_link_url( idr_ppr ) +"</td></tr>"
+		if ( idr_opt!="" ) html += "<tr data-tt-id='idr_opt' data-tt-parent-id='idr'><td>" + "Optimal set"+ "</td><td>"+ _html_link_url( idr_opt ) +"</td></tr>"
+		if ( idr_consv!="" ) html += "<tr data-tt-id='idr_consv' data-tt-parent-id='idr'><td>" + "Conservative set"+ "</td><td>"+ _html_link_url( idr_consv ) +"</td></tr>"
 	}
 
 	html += "</tbody></table>"
@@ -908,8 +908,8 @@ string _html_atac_QC() {
 	}
 
 	html := "<div id='atac_qc'>"
-	
-	html += _parse_align_log_to_html( "all", 	align_headers, align_qcs, align_headers ) 
+
+	html += _parse_align_log_to_html( "all", 	align_headers, align_qcs, align_headers )
 	html += _parse_dup_to_html( "all", 		dup_headers, dup_qcs, dup_headers )
 	html += _parse_flagstat_to_html( "all, filtered",flagstat_nodup_headers, flagstat_nodup_qcs, flagstat_nodup_headers )
 	html += _parse_pbc_to_html( "all", 		pbc_headers, pbc_qcs, pbc_headers )
@@ -1095,7 +1095,7 @@ string[] _report_atac( string o_dir, string info ) {
 
 		sys echo "\end{multicols}  " >> $tex_file
 		sys echo "%\pagebreak" >> $tex_file
-		sys echo "\end{document}" >> $tex_file		
+		sys echo "\end{document}" >> $tex_file
 
 		//# now generate the pdf report (appears as *.report.pdf)
 		//sys cd $o_dir
@@ -1123,7 +1123,7 @@ bool is_input_legacy() {
 		ret = true
 
 		for (int i=0; i<8;i++) {
-			
+
 			if ( args[i].startsWith("-") ) {
 				ret = false
 				break
@@ -1158,7 +1158,7 @@ int get_num_rep() {
 
 		if ( get_num_rep_fastq()==2 ) {
 
-			fastqs := get_fastqs( 0, 1 )			
+			fastqs := get_fastqs( 0, 1 )
 
 			if ( !se && fastqs.size()<2 ) return 1
 		}


### PR DESCRIPTION
@leepc12 PTAL - this fixes the crashes described in kundajelab/TF_chipseq_pipeline#2

- Added [replicate index](https://github.com/kundajelab/bds_atac/compare/bam_to_bed_crash_fix?expand=1#diff-2eb69f958339eebb2b4640e60648e98fR500) for bam file when calling `_bam_to_bed_atac`
- Ran lint to remove extra whitespace