### PR TITLE
Fixing dependency syntax problem with graphviz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ libgfortran==3.0 # ataqc
 pandas ==0.18.0 #==0.16.1 # ataqc
 metaseq #==0.5.6 # ataqc
 jinja2 # ataqc
-graphviz=2.38.0=1
+graphviz==2.38.0
 libtool
 ghostscript # pdf2png
 gsl # for preseq


### PR DESCRIPTION
Current version resulted in the error:

    Using Anaconda API: https://api.anaconda.org
    Fetching package metadata: ....
    Solving package specifications: .
    Error:  Package missing in current linux-64 channels: 
      - biobuilds/graphviz
    
    You can search for this package on anaconda.org with
    
        anaconda search -t conda biobuilds/graphviz

Removing =1 from the end fixes this issue.