### PR TITLE
Fix numpy openblas bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ ucsc-bigWigAverageOverBed
 macs2 ==2.1.0
 boost ==1.57.0
 gnuplot ==5.0.3
-numpy ==1.10.4 #1.9.0, 1.8.2 conflicts with ATAQC
+numpy ==1.10.2 #1.9.0, 1.8.2 conflicts with ATAQC
 scipy ==0.17.0 
 matplotlib
 pybedtools # ataqc


### PR DESCRIPTION
Conda-installed numpy 1.10.4 has an import error with openblas:
```
ImportError: libopenblasp-r0-39a31c03.2.18.so: cannot open shared object file: No such file or directory
```
This bug is also documented here: https://jira.slac.stanford.edu/browse/PSRT-105

I was able to fix by downgrading numpy to 1.10.2.